### PR TITLE
Feature/kyungjin06 - 이미지 업로드 & 자격증 정보 업데이트 기능 구현

### DIFF
--- a/lib/data/repository/user_repository.dart
+++ b/lib/data/repository/user_repository.dart
@@ -1,5 +1,4 @@
 import 'dart:io'; 
-import 'package:image_picker/image_picker.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart' as auth;
 import 'package:firebase_storage/firebase_storage.dart';
@@ -54,17 +53,12 @@ class UserRepository {
     }
   }
 
-// 프로필 이미지 업로드 및 URL 업데이트
-  Future<String?> uploadProfileImage(String userId, XFile image) async {
+  // 프로필 이미지 업로드
+  Future<String?> uploadProfileImage(String userId, File imageFile) async {
     try {
-      // Firebase Storage에 이미지 업로드
-      final storageRef = _storage.ref().child('profile_images/$userId/${image.name}');
-      await storageRef.putFile(File(image.path));
-      // 업로드된 이미지의 다운로드 URL 가져오기
-      final downloadUrl = await storageRef.getDownloadURL();
-      // Firestore에 프로필 이미지 URL 업데이트
-      await updateUser(userId, {'profileImageUrl': downloadUrl});
-      return downloadUrl;
+      final ref = _storage.ref().child('profile_images/$userId');
+      await ref.putFile(imageFile);
+      return await ref.getDownloadURL();
     } catch (e) {
       throw Exception('프로필 이미지 업로드 중 오류가 발생했습니다: $e');
     }

--- a/lib/data/repository/user_repository.dart
+++ b/lib/data/repository/user_repository.dart
@@ -1,4 +1,4 @@
-import 'dart:io'; 
+import 'dart:io';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart' as auth;
 import 'package:firebase_storage/firebase_storage.dart';
@@ -10,7 +10,7 @@ class UserRepository {
   // Firebase Authentication 인스턴스
   final auth.FirebaseAuth _auth = auth.FirebaseAuth.instance;
   // Firebase Storage 인스턴스
-  final FirebaseStorage _storage = FirebaseStorage.instance; 
+  final FirebaseStorage _storage = FirebaseStorage.instance;
 
   // 새 사용자 생성
   Future<void> createUser(AppUser user) async {
@@ -130,6 +130,19 @@ class UserRepository {
     } catch (e) {
       print('현재 사용자의 자격증 정보를 가져오는 중 오류 발생: $e');
       return null;
+    }
+  }
+
+  // 자격증 정보 업데이트
+  Future<void> updateCertification(
+      String userId, String type, String level) async {
+    try {
+      await _firestore.collection('users').doc(userId).update({
+        'certificationType': type,
+        'certificationLevel': level,
+      });
+    } catch (e) {
+      throw Exception('자격증 정보를 업데이트하는 중 오류가 발생했습니다: $e');
     }
   }
 }

--- a/lib/ui/pages/home/_tab/my_profile_tab/profile_tab.dart
+++ b/lib/ui/pages/home/_tab/my_profile_tab/profile_tab.dart
@@ -12,8 +12,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 class ProfileTab extends ConsumerWidget {
   const ProfileTab({super.key});
 
-    // 하단 카드 스쿠버, 프리다이빙 표시 함수  
-    String _formatCertificationType(String type) {
+  // 하단 카드 스쿠버, 프리다이빙 표시 함수
+  String _formatCertificationType(String type) {
     switch (type) {
       case 'scuba':
         return 'Scubadiving';
@@ -59,15 +59,44 @@ class ProfileTab extends ConsumerWidget {
                 child: Column(
                   children: [
                     const SizedBox(height: 30),
-                    CircleAvatar(
-                      radius: 50,
-                      backgroundColor: Colors.grey[200],
-                      backgroundImage: user.profileImageUrl != null &&
-                              user.profileImageUrl!.startsWith('http')
-                          ? NetworkImage(user.profileImageUrl!)
-                          : AssetImage(
-                                  'assets/images/default_profile_image.png')
-                              as ImageProvider,
+                    Center(
+                      child: Stack(
+                        children: [
+                          // 그림자 효과
+                          Container(
+                            width: 100,
+                            height: 100,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.black.withOpacity(0.1),
+                                  blurRadius: 20,
+                                  spreadRadius: 1,
+                                  offset: const Offset(-3, -3), // 왼쪽 위 그림자
+                                ),
+                                BoxShadow(
+                                  color: Colors.black.withOpacity(0.1),
+                                  blurRadius: 20,
+                                  spreadRadius: 1,
+                                  offset: const Offset(3, 3), // 오른쪽 아래 그림자
+                                ),
+                              ],
+                            ),
+                          ),
+                          // 프로필 이미지
+                          CircleAvatar(
+                            radius: 50,
+                            backgroundColor: Colors.grey[200],
+                            backgroundImage: user.profileImageUrl != null &&
+                                    user.profileImageUrl!.startsWith('http')
+                                ? NetworkImage(user.profileImageUrl!)
+                                : const AssetImage(
+                                        'assets/images/default_profile_image.png')
+                                    as ImageProvider,
+                          ),
+                        ],
+                      ),
                     ),
                     const SizedBox(height: 20),
                     Text(

--- a/lib/ui/pages/home/_tab/my_profile_tab/profile_tab.dart
+++ b/lib/ui/pages/home/_tab/my_profile_tab/profile_tab.dart
@@ -27,7 +27,8 @@ class ProfileTab extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final userRepository = ref.watch(userRepositoryProvider);
-    final userFuture = userRepository.getUser(userRepository.getCurrentUserId());
+    final userFuture =
+        userRepository.getUser(userRepository.getCurrentUserId());
 
     return Scaffold(
       appBar: const ProfileTabAppBar(),
@@ -58,11 +59,17 @@ class ProfileTab extends ConsumerWidget {
                 child: Column(
                   children: [
                     const SizedBox(height: 20),
-                    UserProfileImage(
-                      dimension: 100,
-                      imgUrl: '',
+                    CircleAvatar(
+                      radius: 50,
+                      backgroundColor: Colors.grey[200],
+                      backgroundImage: user.profileImageUrl != null &&
+                              user.profileImageUrl!.startsWith('http')
+                          ? NetworkImage(user.profileImageUrl!)
+                          : AssetImage(
+                                  'assets/images/default_profile_image.png')
+                              as ImageProvider,
                     ),
-                    const SizedBox(height: 30),
+                    const SizedBox(height: 20),
                     Text(
                       user.nickname,
                       style: const TextStyle(
@@ -90,7 +97,8 @@ class ProfileTab extends ConsumerWidget {
                         onPressed: () async {
                           final result = await Navigator.push(
                             context,
-                            MaterialPageRoute(builder: (context) => const ProfileEditPage()),
+                            MaterialPageRoute(
+                                builder: (context) => const ProfileEditPage()),
                           );
                           if (result == true) {
                             _showToast('수정이 완료되었습니다.');
@@ -137,7 +145,8 @@ class ProfileTab extends ConsumerWidget {
                 onTap: () {
                   Navigator.push(
                     context,
-                    MaterialPageRoute(builder: (context) => const CertificationEditPage()),
+                    MaterialPageRoute(
+                        builder: (context) => const CertificationEditPage()),
                   );
                 },
               ),

--- a/lib/ui/pages/home/_tab/my_profile_tab/profile_tab.dart
+++ b/lib/ui/pages/home/_tab/my_profile_tab/profile_tab.dart
@@ -6,7 +6,6 @@ import 'package:flutter_application_seau/ui/pages/mypage/certification_edit/cert
 import 'package:flutter_application_seau/ui/pages/mypage/profile_edit/profile_edit_page.dart';
 import 'package:flutter_application_seau/ui/pages/mypage/widgets/info_card.dart';
 import 'package:flutter_application_seau/ui/widgets/primary_button.dart';
-import 'package:flutter_application_seau/ui/widgets/user_profile_image.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 
@@ -58,7 +57,7 @@ class ProfileTab extends ConsumerWidget {
                 padding: const EdgeInsets.only(bottom: 40), // 프로필 섹션 하단 패딩
                 child: Column(
                   children: [
-                    const SizedBox(height: 20),
+                    const SizedBox(height: 30),
                     CircleAvatar(
                       radius: 50,
                       backgroundColor: Colors.grey[200],
@@ -73,11 +72,11 @@ class ProfileTab extends ConsumerWidget {
                     Text(
                       user.nickname,
                       style: const TextStyle(
-                        fontSize: 20,
+                        fontSize: 25,
                         fontWeight: FontWeight.bold,
                       ),
                     ),
-                    const SizedBox(height: 5),
+                    const SizedBox(height: 3),
                     Text(
                       user.location,
                       style: const TextStyle(fontSize: 16, color: Colors.black),

--- a/lib/ui/pages/home/_tab/my_profile_tab/profile_tab.dart
+++ b/lib/ui/pages/home/_tab/my_profile_tab/profile_tab.dart
@@ -5,22 +5,23 @@ import 'package:flutter_application_seau/ui/pages/join/join_view_model.dart';
 import 'package:flutter_application_seau/ui/pages/mypage/certification_edit/certification_edit_page.dart';
 import 'package:flutter_application_seau/ui/pages/mypage/profile_edit/profile_edit_page.dart';
 import 'package:flutter_application_seau/ui/pages/mypage/widgets/info_card.dart';
+import 'package:flutter_application_seau/ui/widgets/common_toast.dart';
 import 'package:flutter_application_seau/ui/widgets/primary_button.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 
 class ProfileTab extends ConsumerWidget {
   const ProfileTab({super.key});
 
-  void _showToast(String message) {
-    Fluttertoast.showToast(
-      msg: message,
-      toastLength: Toast.LENGTH_SHORT,
-      gravity: ToastGravity.BOTTOM,
-      backgroundColor: Colors.black87,
-      textColor: Colors.white,
-      fontSize: 16.0,
-    );
+    // 하단 카드 스쿠버, 프리다이빙 표시 함수  
+    String _formatCertificationType(String type) {
+    switch (type) {
+      case 'scuba':
+        return 'Scubadiving';
+      case 'freediving':
+        return 'Freediving';
+      default:
+        return type; // 기본값
+    }
   }
 
   @override
@@ -100,7 +101,7 @@ class ProfileTab extends ConsumerWidget {
                                 builder: (context) => const ProfileEditPage()),
                           );
                           if (result == true) {
-                            _showToast('수정이 완료되었습니다.');
+                            showToast('수정이 완료되었습니다.');
                           }
                         },
                       ),
@@ -122,7 +123,7 @@ class ProfileTab extends ConsumerWidget {
                           const Icon(Icons.verified, color: Colors.blue),
                           const SizedBox(width: 5),
                           Text(
-                            user.certificationLevel,
+                            _formatCertificationType(user.certificationLevel),
                             style: const TextStyle(fontSize: 16),
                           ),
                         ],
@@ -133,7 +134,7 @@ class ProfileTab extends ConsumerWidget {
                           const Icon(Icons.waves, color: Colors.blue),
                           const SizedBox(width: 5),
                           Text(
-                            user.certificationType,
+                            _formatCertificationType(user.certificationType),
                             style: const TextStyle(fontSize: 16),
                           ),
                         ],
@@ -141,12 +142,15 @@ class ProfileTab extends ConsumerWidget {
                     ],
                   ),
                 ),
-                onTap: () {
-                  Navigator.push(
+                onTap: () async {
+                  final result = await Navigator.push(
                     context,
                     MaterialPageRoute(
                         builder: (context) => const CertificationEditPage()),
                   );
+                  if (result == true) {
+                    showToast('수정이 완료되었습니다.');
+                  }
                 },
               ),
             ],

--- a/lib/ui/pages/mypage/certification_edit/certification_edit_view_model.dart
+++ b/lib/ui/pages/mypage/certification_edit/certification_edit_view_model.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_application_seau/data/model/app_user.dart';
+import 'package:flutter_application_seau/ui/pages/join/join_view_model.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_application_seau/data/repository/user_repository.dart';
+
+class CertificationEditViewModel extends StateNotifier<AppUser?> {
+  CertificationEditViewModel(this._userRepository) : super(null);
+
+  final UserRepository _userRepository;
+
+
+  // 사용자 데이터 로드
+  Future<void> loadUserData() async {
+    final userId = _userRepository.getCurrentUserId();
+    final userData = await _userRepository.getUser(userId);
+    state = userData;
+  }
+
+  // user getter 추가
+  AppUser? get user => state;
+
+  // 자격증 정보 업데이트
+  Future<void> updateCertification(String type, String level) async {
+    try {
+      final userId = _userRepository.getCurrentUserId();
+      await _userRepository.updateCertification(userId, type, level);
+    } catch (e) {
+      throw Exception('자격증 정보를 업데이트하는 중 오류가 발생했습니다: $e');
+    }
+  }
+}
+
+// Provider 정의
+final certificationEditViewModelProvider =
+    StateNotifierProvider<CertificationEditViewModel, AppUser?>((ref) {
+  final userRepository = ref.watch(userRepositoryProvider);
+  return CertificationEditViewModel(userRepository);
+});

--- a/lib/ui/pages/mypage/profile_edit/profile_edit_page.dart
+++ b/lib/ui/pages/mypage/profile_edit/profile_edit_page.dart
@@ -190,8 +190,9 @@ class _ProfileEditPageState extends ConsumerState<ProfileEditPage> {
                           nicknameController.text != user.nickname;
                   final isLocationChanged = currentLocation != null &&
                       currentLocation != initialLocation;
+                  final isImageUpdated = profileEditViewModel.isImageUpdated;
 
-                  if (!isNicknameChanged && !isLocationChanged) {
+                  if (!isNicknameChanged && !isLocationChanged && !isImageUpdated) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(content: Text('수정할 내용이 없습니다.')),
                     );

--- a/lib/ui/pages/mypage/profile_edit/profile_edit_page.dart
+++ b/lib/ui/pages/mypage/profile_edit/profile_edit_page.dart
@@ -82,12 +82,13 @@ class _ProfileEditPageState extends ConsumerState<ProfileEditPage> {
             const SizedBox(height: 20),
             // 1. 프로필 이미지
             Center(
-              child: UserProfileImage(
-                dimension: 100,
-                imgUrl: '', // 이미지 URL이 없으면 기본 아이콘 표시
-                onEdit: () {
-                  // 프로필 이미지 수정 로직
-                },
+              child: CircleAvatar(
+                radius: 60,
+                backgroundImage: user.profileImageUrl != null &&
+                        user.profileImageUrl!.isNotEmpty
+                    ? NetworkImage(user.profileImageUrl!)
+                    : AssetImage('assets/images/default_profile_image.png')
+                        as ImageProvider,
               ),
             ),
             const SizedBox(height: 40),

--- a/lib/ui/pages/mypage/profile_edit/profile_edit_page.dart
+++ b/lib/ui/pages/mypage/profile_edit/profile_edit_page.dart
@@ -123,14 +123,12 @@ class _ProfileEditPageState extends ConsumerState<ProfileEditPage> {
             // 3. 닉네임 입력 필드
             CustomTextField(
               label: '닉네임',
-              hintText: 'akeetuitui',
               textcontroller: nicknameController,
             ),
             const SizedBox(height: 25),
             // 4. 이메일 입력 필드
             CustomTextField(
               label: '이메일',
-              hintText: 'divinglover@gmail.com',
               readOnly: true,
               textcontroller: emailController,
               style: const TextStyle(color: Colors.grey),

--- a/lib/ui/pages/mypage/profile_edit/profile_edit_page.dart
+++ b/lib/ui/pages/mypage/profile_edit/profile_edit_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_application_seau/ui/pages/mypage/address_edit/address_edit_page.dart';
 import 'package:flutter_application_seau/ui/pages/mypage/profile_edit/profile_edit_view_model.dart';
 import 'package:flutter_application_seau/ui/widgets/primary_button.dart';
-import 'package:flutter_application_seau/ui/widgets/user_profile_image.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class ProfileEditPage extends ConsumerStatefulWidget {
@@ -82,13 +81,52 @@ class _ProfileEditPageState extends ConsumerState<ProfileEditPage> {
             const SizedBox(height: 20),
             // 1. 프로필 이미지
             Center(
-              child: CircleAvatar(
-                radius: 60,
-                backgroundImage: user.profileImageUrl != null &&
-                        user.profileImageUrl!.isNotEmpty
-                    ? NetworkImage(user.profileImageUrl!)
-                    : AssetImage('assets/images/default_profile_image.png')
-                        as ImageProvider,
+              child: GestureDetector(
+                onTap: () async {
+                  await profileEditViewModel.pickProfileImage();
+                },
+                child: Stack(
+                  alignment: Alignment.bottomRight,
+                  children: [
+                    CircleAvatar(
+                      radius: 60,
+                      backgroundImage: user.profileImageUrl != null &&
+                              user.profileImageUrl!.isNotEmpty
+                          ? NetworkImage(user.profileImageUrl!)
+                          : const AssetImage(
+                                  'assets/images/default_profile_image.png')
+                              as ImageProvider,
+                    ),
+                    // 이미지 수정 아이콘
+                    Positioned(
+                      bottom: 0,
+                      right: 0,
+                      child: Container(
+                        padding: const EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          color: Colors.white,
+                          shape: BoxShape.circle,
+                          border: Border.all(
+                            color: Colors.grey,
+                            width: 0.5,
+                          ),
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black26,
+                              blurRadius: 3, 
+                              offset: Offset(0, 3), 
+                            ),
+                          ],
+                        ),
+                        child: const Icon(
+                          Icons.edit,
+                          color: Colors.grey,
+                          size: 18,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
             const SizedBox(height: 40),

--- a/lib/ui/pages/mypage/profile_edit/profile_edit_view_model.dart
+++ b/lib/ui/pages/mypage/profile_edit/profile_edit_view_model.dart
@@ -2,6 +2,7 @@ import 'package:flutter_application_seau/ui/pages/join/join_view_model.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_application_seau/data/model/app_user.dart';
 import 'package:flutter_application_seau/data/repository/user_repository.dart';
+import 'package:image_picker/image_picker.dart';
 
 // 1. 클래스 생성
 // 2. 뷰모델 만들기
@@ -11,6 +12,7 @@ class ProfileEditViewModel extends StateNotifier<AppUser?> {
   }
 
   final UserRepository _userRepository;
+  final ImagePicker _picker = ImagePicker();
 
   // 사용자 데이터 로드
   Future<void> loadUserData() async {
@@ -39,7 +41,25 @@ class ProfileEditViewModel extends StateNotifier<AppUser?> {
       state = state?.copyWith(nickname: nickname, location: location);
     }
   }
+  
+   // 이미지 선택 및 업로드 메서드
+  Future<void> pickAndUploadProfileImage() async {
+    try {
+      final pickedFile = await _picker.pickImage(source: ImageSource.gallery);
+
+      if (pickedFile != null) {
+        final userId = _userRepository.getCurrentUserId();
+        final imageUrl = await _userRepository.uploadProfileImage(userId, pickedFile);
+
+        // 상태 업데이트
+        state = state?.copyWith(profileImageUrl: imageUrl);
+      }
+    } catch (e) {
+      throw Exception('이미지 업로드 중 오류가 발생했습니다: $e');
+    }
+  }
 }
+
 
 // Provider 정의
 final profileEditViewModelProvider =

--- a/lib/ui/pages/mypage/profile_edit/profile_edit_view_model.dart
+++ b/lib/ui/pages/mypage/profile_edit/profile_edit_view_model.dart
@@ -1,11 +1,10 @@
+import 'dart:io';
 import 'package:flutter_application_seau/ui/pages/join/join_view_model.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_application_seau/data/model/app_user.dart';
 import 'package:flutter_application_seau/data/repository/user_repository.dart';
-import 'package:image_picker/image_picker.dart';
 
-// 1. 클래스 생성
-// 2. 뷰모델 만들기
 class ProfileEditViewModel extends StateNotifier<AppUser?> {
   ProfileEditViewModel(this._userRepository) : super(null) {
     loadUserData();
@@ -13,11 +12,12 @@ class ProfileEditViewModel extends StateNotifier<AppUser?> {
 
   final UserRepository _userRepository;
   final ImagePicker _picker = ImagePicker();
+  File? _selectedImage;
 
   // 사용자 데이터 로드
   Future<void> loadUserData() async {
     try {
-      final userId = _userRepository.getCurrentUserId(); // 현재 로그인한 사용자 ID 가져오기
+      final userId = _userRepository.getCurrentUserId();
       final user = await _userRepository.getUser(userId);
       state = user;
     } catch (e) {
@@ -25,41 +25,46 @@ class ProfileEditViewModel extends StateNotifier<AppUser?> {
     }
   }
 
+  // 이미지 선택
+  Future<void> pickProfileImage() async {
+    final pickedFile = await _picker.pickImage(source: ImageSource.gallery);
+    if (pickedFile != null) {
+      _selectedImage = File(pickedFile.path);
+    }
+  }
 
-  // 프로필 업데이트 메서드
+  // 프로필 업데이트 (이미지, 닉네임, 위치)
   Future<void> updateUserProfile({
     required String userId,
     String? nickname,
-    String? location
-    }) async {
+    String? location,
+  }) async {
     final updatedFields = <String, dynamic>{};
+
+    // 프로필 이미지 업로드
+    if (_selectedImage != null) {
+      final imageUrl = await _userRepository.uploadProfileImage(userId, _selectedImage!);
+      if (imageUrl != null) {
+        updatedFields['profileImageUrl'] = imageUrl;
+      }
+    }
+
+    // 닉네임과 위치 업데이트
     if (nickname != null && nickname.isNotEmpty) updatedFields['nickname'] = nickname;
     if (location != null && location.isNotEmpty) updatedFields['location'] = location;
 
     if (updatedFields.isNotEmpty) {
       await _userRepository.updateUser(userId, updatedFields);
-      state = state?.copyWith(nickname: nickname, location: location);
-    }
-  }
-  
-   // 이미지 선택 및 업로드 메서드
-  Future<void> pickAndUploadProfileImage() async {
-    try {
-      final pickedFile = await _picker.pickImage(source: ImageSource.gallery);
-
-      if (pickedFile != null) {
-        final userId = _userRepository.getCurrentUserId();
-        final imageUrl = await _userRepository.uploadProfileImage(userId, pickedFile);
-
-        // 상태 업데이트
-        state = state?.copyWith(profileImageUrl: imageUrl);
-      }
-    } catch (e) {
-      throw Exception('이미지 업로드 중 오류가 발생했습니다: $e');
+      state = state?.copyWith(
+        profileImageUrl: updatedFields['profileImageUrl'] ?? state?.profileImageUrl,
+        nickname: nickname ?? state?.nickname,
+        location: location ?? state?.location,
+      );
+    } else {
+      throw Exception('수정 내역이 없습니다.');
     }
   }
 }
-
 
 // Provider 정의
 final profileEditViewModelProvider =

--- a/lib/ui/pages/mypage/profile_edit/profile_edit_view_model.dart
+++ b/lib/ui/pages/mypage/profile_edit/profile_edit_view_model.dart
@@ -12,6 +12,9 @@ class ProfileEditViewModel extends StateNotifier<AppUser?> {
 
   final UserRepository _userRepository;
   final ImagePicker _picker = ImagePicker();
+  bool _isImageUpdated = false; // 이미지가 업데이트 됐는지 확인
+
+  bool get isImageUpdated => _isImageUpdated;
 
   // 사용자 데이터 로드
   Future<void> loadUserData() async {
@@ -37,6 +40,7 @@ class ProfileEditViewModel extends StateNotifier<AppUser?> {
           await _userRepository.updateUser(userId, {'profileImageUrl': imageUrl});
           // 상태 업데이트
           state = state?.copyWith(profileImageUrl: imageUrl);
+          _isImageUpdated = true; // 이미지를 선택하면 true로 설정
         }
       }
     } catch (e) {
@@ -51,6 +55,11 @@ class ProfileEditViewModel extends StateNotifier<AppUser?> {
     String? location,
   }) async {
     final updatedFields = <String, dynamic>{};
+
+      if (_isImageUpdated) {
+      updatedFields['profileImageUrl'] = state?.profileImageUrl;
+      _isImageUpdated = false; // 플래그 초기화
+    }
 
     // 닉네임과 위치 업데이트
     if (nickname != null && nickname.isNotEmpty) updatedFields['nickname'] = nickname;

--- a/lib/ui/widgets/common_toast.dart
+++ b/lib/ui/widgets/common_toast.dart
@@ -1,0 +1,13 @@
+import 'package:fluttertoast/fluttertoast.dart';
+import 'package:flutter/material.dart';
+
+void showToast(String message) {
+  Fluttertoast.showToast(
+    msg: '  $message  ',
+    toastLength: Toast.LENGTH_SHORT,
+    gravity: ToastGravity.BOTTOM,
+    backgroundColor: Colors.black87,
+    textColor: Colors.white,
+    fontSize: 16.0,
+  );
+}


### PR DESCRIPTION
**이미지 업로드**
1. 이미지 피커 기능 추가
2. 이미지를 선택함과 동시에 Firebase 업데이트
3. 업데이트 후 <수정완료> 버튼

**자격증 정보**
1. 자격증 정보 가져와서 certification edit page의 Initstate로 설정
2. 자격증 정보 수정 하고 <수정완료> 버튼 누를 시 firebase 업데이트 / 이전 페이지로 복귀 & 토스트창 노출
3. 자격증 정보가 이전과 같을 시 버튼을 눌러도 수정이 되지 않으며 "수정 내역이 없습니다" 표시

**추가기능 및 참고사항**
1. 토스트 메시지창 위젯화
2. 추후 프로필 이미지 위젯 수정 필요